### PR TITLE
fix #118 #119 and bump version and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## [0.4.1] - 2025-10-17
+This is a **preproduction alpha release**, not yet fit for production and operational environments.
+This release should only be used for:
+- testing
+- piloting
+- evaluation purposes
+
+Feedback and bug reports are highly appreciated to improve future versions.
+
+### Added
+- Selection option for processing for reading videos in one go or in chunks. The first is faster and more reliable
+  and will work under most circumstances. The second can be used if very little memory is available.
+### Changed
+- With "shutdown after task" set to true in the daemon settings, the device will give you a 15 second time delay
+  before shutting down. This is to allow for a user to enter the device in case it only appears online late in the
+  process. This happens for instance with Starlink modems, that are started up at the same time as the device.
+  These modems take a significant while to start up.
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+
 ## [0.4.0] - 2025-10-16
 This is a **preproduction alpha release**, not yet fit for production and operational environments.
 This release should only be used for:

--- a/dashboard/src/api/api.js
+++ b/dashboard/src/api/api.js
@@ -49,7 +49,6 @@ export const createWebSocketConnection = (connectionId, url, onMessageCallback, 
       return webSocketInstances[connectionId];
    }
    const socketUrl = 'ws://' + window.location.host + API_BASE + url;
-  console.log("SocketUrl", socketUrl)
    const webSocket = new WebSocket(socketUrl);  // prepend the ws prefix
 
    // Event: WebSocket successfully opened

--- a/dashboard/src/views/recipeComponents/recipeForm.jsx
+++ b/dashboard/src/views/recipeComponents/recipeForm.jsx
@@ -33,6 +33,7 @@ const RecipeForm = ({selectedRecipe, setSelectedRecipe, frameCount, setMessageIn
         id: selectedRecipe.id || '',
         start_frame: selectedRecipe.start_frame,
         end_frame: selectedRecipe.end_frame || '',
+        lazy: selectedRecipe.lazy || false,
         freq: selectedRecipe.freq || '',
         resolution: selectedRecipe.resolution || '',
         window_size: selectedRecipe.window_size || '',
@@ -143,6 +144,7 @@ const RecipeForm = ({selectedRecipe, setSelectedRecipe, frameCount, setMessageIn
       data: safelyParseJSON(formData.data),
       start_frame: formData.start_frame,
       end_frame: formData.end_frame,
+      lazy: formData.lazy,
       freq: formData.freq,
       resolution: formData.resolution,
       window_size: formData.window_size,
@@ -193,6 +195,25 @@ const RecipeForm = ({selectedRecipe, setSelectedRecipe, frameCount, setMessageIn
       console.error('Error updating recipe:', error);
     }
   }
+
+  const handleInputBooleanChange = async (event) => {
+
+    const {name, value, type} = event.target;
+    const booleanValue = value === "true" ? true : value === "false" ? false : null;
+    const updatedFormData = {
+      ...formData,
+      [name]: booleanValue,
+    }
+    setFormData(updatedFormData);
+    console.log(updatedFormData);
+    try {
+      const response = await api.post('/recipe/update/', submitData(updatedFormData));
+      setSelectedRecipe(response.data);
+    } catch (error) {
+      console.error('Error updating recipe:', error);
+    }
+  }
+
 
   const handleFrameChange = async (values) => {
     const minimumDifference = 10;
@@ -302,6 +323,7 @@ const RecipeForm = ({selectedRecipe, setSelectedRecipe, frameCount, setMessageIn
         id: '',
         start_frame: '',
         end_frame: '',
+        // lazy: '',
         freq: '',
         resolution: '',
         data: ''
@@ -363,6 +385,38 @@ const RecipeForm = ({selectedRecipe, setSelectedRecipe, frameCount, setMessageIn
             />
             </div>
           </div>
+          <div className="mb-3 mt-3 form-horizontal" onChange={handleInputBooleanChange}>
+            <label htmlFor="lazy" className="form-label">
+              Read frames in one go or in smaller chunks?
+            </label>
+            <div className="form-check">
+              <input
+                className="form-check-input"
+                type="radio"
+                name="lazy"
+                id="false"
+                value="false"
+                checked={!formData.lazy}
+              />
+              <label className="form-check-label" htmlFor="grayscale">
+                In one go
+              </label>
+            </div>
+            <div className="form-check">
+              <input
+                className="form-check-input"
+                type="radio"
+                name="lazy"
+                id="true"
+                value="true"
+                checked={formData.lazy}
+              />
+              <label className="form-check-label" htmlFor="hue">
+                In chunks (less reliable with some video formats)
+              </label>
+            </div>
+          </div>
+
           <div className='mb-3 mt-3 form-horizontal'>
             <label htmlFor='freq' className='form-label'>
               Resample frame distance [-]

--- a/dashboard/src/views/videoComponents/paginatedVideos.jsx
+++ b/dashboard/src/views/videoComponents/paginatedVideos.jsx
@@ -95,7 +95,6 @@ const PaginatedVideos = ({startDate, endDate, setStartDate, setEndDate, videoRun
   }, [showConfigModal]);
 
   useEffect(() => {
-    console.log("videoRunState was updated", videoRunState)
     if (!videoRunState) return;
     setData(prevData => {
       return prevData.map(video => {
@@ -503,6 +502,7 @@ PaginatedVideos.propTypes = {
   endDate: PropTypes.string,
   setStartDate: PropTypes.func.isRequired,
   setEndDate: PropTypes.func.isRequired,
+  videoRunState: PropTypes.object,
 };
 
 export default PaginatedVideos;

--- a/orc_api/__init__.py
+++ b/orc_api/__init__.py
@@ -4,7 +4,7 @@ import os
 import socket
 import warnings
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 # default key in case none is set in env variables
 ORC_DEFAULT_KEY = "ORC_DEFAULT_KEY"
@@ -40,6 +40,8 @@ for port in ports:
 
 __home__ = os.getenv("ORC_HOME")
 UPLOAD_DIRECTORY = os.getenv("ORC_UPLOAD_DIRECTORY")
+timeout_before_shutdown = os.getenv("ORC_TIMEOUT_BEFORE_SHUTDOWN", 15)
+
 if not __home__:
     __home__ = os.path.join(os.path.expanduser("~"), ".ORC-OS")
 if not (os.path.isdir(__home__)):

--- a/orc_api/schemas/recipe.py
+++ b/orc_api/schemas/recipe.py
@@ -15,6 +15,7 @@ class VideoData(BaseModel):
     start_frame: int = Field(default=0)
     end_frame: Optional[int] = Field(default=10)
     freq: int = Field(default=1)
+    lazy: bool = Field(default=False)
 
 
 class FramesData(BaseModel):
@@ -131,6 +132,7 @@ class RecipeResponse(RecipeRemote):
     id: Optional[int] = Field(default=None, description="Recipe ID")
     start_frame: int = Field(default=0, description="Frame number of the first frame of the recipe.")
     end_frame: int = Field(default=150, description="Frame number of the last frame to process.")
+    lazy: bool = Field(default=False, description="Lazy loading of videos.")
     freq: int = Field(default=1, description="Frame frequency.")
     resolution: float = Field(
         default=0.01, ge=0.001, le=0.05, description="Resolution of the projected video in meters."
@@ -195,6 +197,7 @@ class RecipeResponse(RecipeRemote):
             data = RecipeData(**instance.data)
         instance.start_frame = data.video.start_frame
         instance.end_frame = data.video.end_frame
+        instance.lazy = data.video.lazy
         instance.freq = data.video.freq
         instance.resolution = data.frames.project["resolution"]
         if "window_size" in data.velocimetry.get_piv:
@@ -266,6 +269,7 @@ class RecipeUpdate(RecipeBase):
     id: Optional[int] = Field(default=None, description="Recipe ID")
     start_frame: Optional[int] = Field(default=None, description="Frame number of the first frame of the recipe.")
     end_frame: Optional[int] = Field(default=None, description="Frame number of the last frame to process.")
+    lazy: Optional[bool] = Field(default=None, description="Lazy loading of videos.")
     freq: Optional[int] = Field(default=None, description="Frame frequency.")
     resolution: Optional[float] = Field(
         default=None, ge=0.001, le=0.05, description="Resolution of the projected video in meters."
@@ -332,6 +336,8 @@ class RecipeUpdate(RecipeBase):
         if instance.end_frame is not None:
             data.video.end_frame = instance.end_frame
             data.water_level.n_end = instance.end_frame
+        if instance.lazy is not None:
+            data.video.lazy = instance.lazy
         data.video.freq = getattr(instance, "freq", 1)
         data.frames.project["resolution"] = getattr(instance, "resolution", 0.02)
         if instance.window_size is not None:

--- a/orc_api/schemas/video.py
+++ b/orc_api/schemas/video.py
@@ -4,6 +4,7 @@ import glob
 import json
 import os
 import subprocess
+import time
 from datetime import datetime
 from typing import Optional
 
@@ -13,7 +14,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from pyorc.service import velocity_flow
 from sqlalchemy.orm import Session
 
-from orc_api import crud
+from orc_api import crud, timeout_before_shutdown
 from orc_api import db as models
 from orc_api.database import get_session
 from orc_api.log import add_filehandler, logger, remove_file_handler
@@ -265,6 +266,8 @@ class VideoResponse(VideoBase, RemoteModel):
 
         # shutdown if this is set
         if shutdown_after_task:
+            logger.info(f"Shutdown triggered by daemon. Shutting down in {timeout_before_shutdown} seconds.")
+            time.sleep(timeout_before_shutdown)
             logger.info("Shutting down after daemon task...Bye bye :-)")
             subprocess.call("sudo shutdown -h now", shell=True)
         # only do a raise after the shutdown has been done, to avoid not shutting down at all.

--- a/tests/test_schemas/test_video_schemas.py
+++ b/tests/test_schemas/test_video_schemas.py
@@ -58,6 +58,9 @@ def test_video_run_daemon_shutdown(tmpdir, video_response_no_ts, session_video_c
     def mock_sync_remote(self, *args, **kwargs):
         return None
 
+    def mock_timeout(self, *args, **kwargs):
+        pass
+
     def mock_subprocess_call(*args, **kwargs):
         print("Shutdown called!")
         raise ShutdownException("Simulating a shutdown")
@@ -66,6 +69,7 @@ def test_video_run_daemon_shutdown(tmpdir, video_response_no_ts, session_video_c
 
     mock_shutdown = mock.Mock(side_effect=mock_subprocess_call)
     monkeypatch.setattr("subprocess.call", mock_shutdown)
+    monkeypatch.setattr("time.sleep", mock_timeout)
     monkeypatch.setattr("orc_api.schemas.video.velocity_flow", mock_velocity_flow)
     monkeypatch.setattr("orc_api.schemas.video.VideoResponse.update_timeseries", mock_update_timeseries)
     monkeypatch.setattr("orc_api.schemas.video.VideoResponse.sync_remote", mock_update_timeseries)


### PR DESCRIPTION
## Issue addressed
Fixes #118 and #119

## Explanation
- Added a 15 second (default) delay to shutdown, which can be configured with an environment variable.
- Added option for lazy (or not) processing, default is False.

## General Checklist
- [x] Updated tests or added new tests
- [x] Fork is up-to-date with `main`
- [x] Tests pass
- [x] Front end functionalities tested
- [x] Updated documentation
- [x] Updated CHANGELOG.md


